### PR TITLE
Add scoring system for games, ratings framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## v0.11 - Game Improvements II, Singleplayer
 
+### v0.11.2 (May 30, 2021)
+[`Add scoring system for games, ratings framework #81`](https://github.com/WillFlame14/jspuyo/pull/81)
+
+**New features:**
+- A rating system very similar to Hiku's Western Ranking has been implemented.
+  - Currently, there is no way to access this rating system as Ranked matches do not function properly yet.
+- Player names are now shown beneath boards to help identify who's who.
+- Lobbies without a win condition now keeps track of total wins in the player list.
+- Lobbies with a FT # win condition now do not return to the lobby between games, and each player's wins are tracked underneath their board.
+
+**Other changes:**
+- Fixed [`#60`](https://github.com/WillFlame14/jspuyo/issues/60), and likely other issues associated with the server not being able to figure out who won a game.
+- CPUs no longer emit gameOver and gameEnd events twice (didn't cause any visible problems, but occasionally had some weird errors).
+- Removed a lot of unnecessary/repeated code.
+
 ### v0.11.1 (March 12, 2021)
 [`Various game fixes #66`](https://github.com/WillFlame14/jspuyo/pull/66)
 

--- a/server.ts
+++ b/server.ts
@@ -131,14 +131,14 @@ io.on('connection', function(socket) {
 		RoomManager.startRoomWithGameId(gameId, socket);
 	});
 
-	socket.on('createRoom', (gameInfo: { gameId: string, settingsString: string, roomSize: number}) => {
-		const { gameId, settingsString, roomSize } = gameInfo;
+	socket.on('createRoom', (gameInfo: { gameId: string, settingsString: string, roomSize: number, roomType: string}) => {
+		const { gameId, settingsString, roomSize, roomType } = gameInfo;
 
 		const members = new Map().set(gameId, { socket, frames: 0 });
 		// Room creator becomes the host
 		const host = gameId;
 
-		const roomId = RoomManager.createRoom(gameId, members, host, roomSize, settingsString).roomId;
+		const roomId = RoomManager.createRoom(gameId, members, host, roomSize, settingsString, roomType).roomId;
 		socket.emit('giveRoomId', roomId);
 	});
 

--- a/server.ts
+++ b/server.ts
@@ -284,13 +284,7 @@ io.on('connection', function(socket) {
 	// Player was eliminated
 	socket.on('gameOver', gameId => {
 		const roomId = RoomManager.getRoomIdFromId(gameId);
-		socket.to(roomId).emit('gameOver', gameId);
 		RoomManager.beenDefeated(gameId, roomId);
-	});
-
-	// Game is over for all players
-	socket.on('gameEnd', roomId => {
-		RoomManager.endRoom(roomId);
 	});
 
 	socket.on('forceDisconnect', (gameId, roomId) => {

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -135,8 +135,8 @@ export class Game {
 					break;
 				case 'Loss':
 					this.audioPlayer.playAndEmitSfx('loss');
-					setTimeout(() => this.audioPlayer.playAndEmitSfx('win'), 2000);
 					this.statTracker.addResult('loss');
+					break;
 			}
 			return this.endResult;
 		}

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -137,7 +137,7 @@ let quickPlayTimer: ReturnType<typeof setTimeout> = null;
 function init(socket: SocketIOClient.Socket): void {
 	socket.on('roomUpdate', (
 		roomId: string,
-		allIds: string[],
+		playerScores: Record<string, number>,
 		roomSize: number,
 		settingsString: string,
 		roomType: string,
@@ -191,7 +191,7 @@ function init(socket: SocketIOClient.Socket): void {
 			statusExtra.style.display = 'block';
 			roomManageOptions.style.display = 'none';
 
-			if (allIds.length === 1) {
+			if (Object.keys(playerScores).length === 1) {
 				statusMsg.innerHTML = 'Waiting for more players to start...';
 				clearInterval(quickPlayTimer);
 				quickPlayTimer = null;
@@ -223,7 +223,7 @@ function init(socket: SocketIOClient.Socket): void {
 			roomManageOptions.style.display = 'block';
 		}
 
-		globalEmitter.emit('updatePlayers', allIds);
+		globalEmitter.emit('updatePlayers', playerScores);
 	});
 
 	socket.on('start', async (roomId: string, opponentIds: string[], settingsString: string) => {

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -12,6 +12,7 @@ export class Room {
 	password: string = null;
 	members: Map<string, { socket: SocketIO.Socket }>;
 	cpus = new Map<string, CpuInfo>();
+	wins: Record<string, number> = {};
 	numCpus = 0;
 	games = new Map<string, { socket: SocketIO.Socket, frames: number, session?: CpuSession }>();
 	host: string;
@@ -45,20 +46,12 @@ export class Room {
 		this.roomType = roomType;
 
 		this.members.forEach((player, gameId) => {
-			// Send update to all players
-			player.socket.emit(
-				'roomUpdate',
-				this.roomId,
-				Array.from(this.members.keys()),
-				this.roomSize,
-				this.settingsString,
-				this.roomType,
-				gameId === this.host,
-				false		// Not spectating
-			);
-
 			player.socket.join(this.roomId);
+			this.wins[gameId] = 0;
 		});
+
+		// Send update to all players
+		this.sendRoomUpdate();
 
 		console.log(`Creating room ${this.roomId} with gameIds: ${JSON.stringify(Array.from(this.members.keys()).map(id => id.substring(0, 6)))}`);
 	}
@@ -103,6 +96,9 @@ export class Room {
 			this.cpus.set(gameId, cpuInfo);
 		}
 		console.log(`Added gameId ${gameId.substring(0, 6)} to room ${this.roomId}`);
+
+		// Set their win count to 0
+		this.wins[gameId] = 0;
 
 		if(notify) {
 			this.sendRoomUpdate();
@@ -215,6 +211,8 @@ export class Room {
 	 * @return {boolean}          True if the room is now empty, and false otherwise.
 	 */
 	leave(gameId: string, notify = true, spectate = false): boolean {
+		this.wins[gameId] = undefined;
+
 		if(this.spectating.has(gameId)) {
 			const socket = this.spectating.get(gameId);
 			socket.leave(this.roomId);
@@ -407,11 +405,15 @@ export class Room {
 
 		// Determine if there is a winner
 		if(this.undefeated.length <= 1) {
-			// If the remaining players lose at the same time, winner will be a blank string
-			const winner = this.undefeated[0] || '';
+			// If the remaining players lose at the same time, winner will be undefined
+			const winner = this.undefeated[0];
 			this.games.forEach((player) => {
 				player.socket.emit('winnerResult', winner);
 			});
+
+			if(winner !== undefined) {
+				this.wins[winner]++;
+			}
 
 			// End room
 			this.end();
@@ -422,9 +424,6 @@ export class Room {
 	 * Sends a room update to all the members and spectators of the room.
 	 */
 	sendRoomUpdate(): void {
-		// Get all display names of members and CPUs
-		const playersInRoom = Array.from(this.members.keys()).concat(Array.from(this.cpus.keys()));
-
 		// Temporary timer if it has not been updated yet
 		let tempTimer = null;
 
@@ -439,7 +438,7 @@ export class Room {
 		this.members.forEach((player, id) => {
 			player.socket.emit('roomUpdate',
 				this.roomId,
-				playersInRoom,
+				this.wins,
 				this.roomSize,
 				this.settingsString,
 				this.roomType,
@@ -452,7 +451,7 @@ export class Room {
 		this.spectating.forEach(socket => {
 			socket.emit('roomUpdate',
 				this.roomId,
-				playersInRoom,
+				this.wins,
 				this.roomSize,
 				this.settingsString,
 				this.roomType,

--- a/src/RoomManager.ts
+++ b/src/RoomManager.ts
@@ -134,18 +134,6 @@ export class RoomManager {
 		return room;
 	}
 
-	static endRoom(roomId: string): Room {
-		const room = roomIdToRoom.get(roomId);
-
-		if(room === undefined) {
-			console.log(`Tried to end room ${roomId}, but it did not exist.`);
-			return;
-		}
-
-		room.end();
-		return room;
-	}
-
 	static leaveRoom(gameId: string, roomId: string = null, notify = false): Room {
 		// The old roomId is explicitly provided when force disconnecting from a room, since joining happens faster than leaving
 		const room = (roomId === null) ? roomIdToRoom.get(idToRoomId.get(gameId)) : roomIdToRoom.get(roomId);
@@ -285,12 +273,7 @@ export class RoomManager {
 		const room = roomIdToRoom.get(roomId);
 
 		if(room !== undefined) {
-			room.defeated.push(gameId);
-
-			// If the remaining players lose at the same time
-			if(room.defeated.length === room.roomSize) {
-				room.end();
-			}
+			room.addDefeat(gameId);
 		}
 	}
 

--- a/src/_css/_base.scss
+++ b/src/_css/_base.scss
@@ -246,3 +246,11 @@ footer {
 .hiddenInfo {
 	display: none;
 }
+
+.centre-align {
+	text-align: center;
+}
+
+.right-align {
+	text-align: right;
+}

--- a/src/_css/_mainpage.scss
+++ b/src/_css/_mainpage.scss
@@ -284,8 +284,9 @@
 // An entry in the player list
 .playerIndividual {
 	display: grid;
-	grid-template-columns: 15% 65% 20%;
-	padding: 8px 5px;
+	grid-column-gap: 10px;
+	grid-template-columns: 1fr 3fr 2fr 2fr;
+	padding: 8px 15px 8px 5px;
 
 	// The icon next to each player's name
 	img {

--- a/src/_css/_mainpage.scss
+++ b/src/_css/_mainpage.scss
@@ -20,11 +20,15 @@
 }
 
 .pointsDisplay {
-	display: table;
-	width: 73%;
-
 	color: white;
 	font: 52px base.$font-title;
+	text-align: center;
+}
+
+.playerDisplay {
+	color: white;
+	font: 32px base.$font-title;
+	white-space: nowrap;
 	text-align: center;
 }
 

--- a/src/utils/Ratings.ts
+++ b/src/utils/Ratings.ts
@@ -1,0 +1,102 @@
+/*
+import { PlayerInfo } from '../webpage/firebase';
+
+	const promises = [
+		PlayerInfo.getUserProperty(uidA, 'rating'),
+		PlayerInfo.getUserProperty(uidB, 'rating'),
+		PlayerInfo.getUserProperty(uidA, 'matches'),
+		PlayerInfo.getUserProperty(uidB, 'matches')
+	];
+
+	const [ratingA, ratingB, matchesA, matchesB] = await Promise.all(promises) as [number, number, Record<string, Match[]>, Record<string, Match[]>];
+
+	if(matchesA[uidB] === undefined) {
+		matchesA[uidB] = [];
+	}
+
+	if(matchesB[uidA] === undefined) {
+		matchesB[uidB] = [];
+	}
+
+	matchesA[uidB].push({ wins: winsA, opponent_wins: winsB, timestamp });
+	matchesA[uidB].push({ wins: winsB, opponent_wins: winsA, timestamp });
+
+	await Promise.all([
+		PlayerInfo.updateUser(uidA, 'matches', matchesA),
+		PlayerInfo.updateUser(uidA, 'matches', matchesB)
+	]);
+ */
+
+
+interface Match {
+	wins: number;
+	opponent_wins: number;
+	timestamp: number;
+}
+
+export function updateRatings(ratingA: number, ratingB: number, winsA: number, winsB: number): { ratingA: number, ratingB: number } {
+	const delta = findDelta(ratingA, ratingB, winsA, winsB);
+
+	let medA: number, medB: number;
+
+	if(delta >= 0) {
+		medA = ratingA * (1 + delta);
+		medB = ratingB / (1 + delta);
+	}
+	else {
+		medA = ratingA / (1 + delta);
+		medB = ratingB * (1 + delta);
+	}
+
+	return {
+		ratingA: medA,
+		ratingB: medB
+	};
+}
+
+/**
+ * Finds the uncertainty of a user's rating.
+ * @param  {number}            			rating     		The user's current rating.
+ * @param  {Record<string, Match[]>} 	all_matches   	All the matches the user has played.
+ * @param  {Record<string, number>}  	all_ratings   	A map of current ratings of all players.
+ * @return {number}                       The user's rating uncertainty.
+ */
+export function findUncertainty(rating: number, all_matches: Record<string, Match[]>, all_ratings: Record<string, number>): number {
+	let total_matchup_str = 0;
+
+	for(const [opponent, matches] of Object.entries(all_matches)) {
+		const level_coefficient = levelCoeff(rating, all_ratings[opponent]);
+
+		let matchup_str = 0;
+
+		for(const match of matches) {
+			const coefficient = findCoefficient(timeCoeff(match.timestamp), level_coefficient);
+			console.log(coefficient);
+			matchup_str += coefficient * (match.wins + match.opponent_wins);
+
+			if(matchup_str > 100) {
+				break;
+			}
+		}
+
+		total_matchup_str += Math.min(Math.sqrt(matchup_str) / 10, 1);
+	}
+
+	return 0.6 / Math.pow(total_matchup_str, 1.2);
+}
+
+export function findDelta(ratingA: number, ratingB: number, winsA: number, winsB: number): number {
+	return (Math.sqrt(ratingB/ratingA) * winsA - Math.sqrt(ratingA/ratingB) * winsB) * findCoefficient(levelCoeff(ratingA, ratingB), 1);
+}
+
+function findCoefficient(level_coefficient: number, time_coefficient): number {
+	return time_coefficient * level_coefficient / 1000;
+}
+
+function timeCoeff(timestamp: number): number {
+	return 1 / (Math.pow((Date.now() - timestamp) / (1000 * 60 * 60 * 24 * 365), 2) + 1);
+}
+
+function levelCoeff(ratingA: number, ratingB: number): number {
+	return Math.min(ratingA/ratingB, ratingB/ratingA);
+}

--- a/src/utils/Ratings.ts
+++ b/src/utils/Ratings.ts
@@ -1,4 +1,5 @@
-/*
+/* To be used when adding support for ranked matches
+----------------------------------------------------------
 import { PlayerInfo } from '../webpage/firebase';
 
 	const promises = [

--- a/src/webpage/PlayerList.ts
+++ b/src/webpage/PlayerList.ts
@@ -10,14 +10,16 @@ interface Player {
 }
 
 export const PlayerList = Vue.defineComponent({
-	data(): { players: Player[], puyoImgs: string[] } {
+	data(): { players: Player[], showWins: boolean, puyoImgs: string[] } {
 		return {
 			players: [],
+			showWins: true,
 			puyoImgs
 		};
 	},
 	mounted() {
-		this.emitter.on('updatePlayers', (playerScores: Record<string, number>) => {
+		this.emitter.on('updatePlayers', ({playerScores, showWins}: { playerScores: Record<string, number>, showWins: boolean }) => {
+			this.showWins = showWins;
 			const promises: (Promise<string> | string)[] = [];
 			// Fetch usernames from the database using the ids
 			for(const [id, wins] of Object.entries(playerScores)) {
@@ -53,7 +55,7 @@ export const PlayerList = Vue.defineComponent({
 			<li class="playerIndividual" v-for="(player, index) in players">
 				<img v-bind:src="'images/modal_boxes/puyo_' + puyoImgs[index % puyoImgs.length] + '.png'">
 				<span >{{player.name}}</span>
-				<span class="centre-align">{{player.wins + '★'}}</span>
+				<span class="centre-align">{{showWins ? player.wins + '★' : ''}}</span>
 				<span class="right-align">{{player.rating}}</span>
 			</li>
 		</ul>`

--- a/src/webpage/PlayerList.ts
+++ b/src/webpage/PlayerList.ts
@@ -5,6 +5,7 @@ import { puyoImgs } from './panels_custom';
 
 interface Player {
 	name: string,
+	wins: number,
 	rating: number
 }
 
@@ -16,10 +17,10 @@ export const PlayerList = Vue.defineComponent({
 		};
 	},
 	mounted() {
-		this.emitter.on('updatePlayers', (players: string[]) => {
+		this.emitter.on('updatePlayers', (playerScores: Record<string, number>) => {
 			const promises: (Promise<string> | string)[] = [];
 			// Fetch usernames from the database using the ids
-			players.forEach(id => {
+			for(const [id, wins] of Object.entries(playerScores)) {
 				if(id.includes('CPU-')) {
 					promises.push(id);
 					promises.push('1000');
@@ -28,14 +29,15 @@ export const PlayerList = Vue.defineComponent({
 					promises.push(PlayerInfo.getUserProperty(id, 'username') as Promise<string>);
 					promises.push(PlayerInfo.getUserProperty(id, 'rating') as Promise<string>);
 				}
-			});
+				promises.push(`${wins}`);
+			}
 
 			// Wait for all promises to resolve, then add them to the player list
 			Promise.all(promises).then(playerInfos => {
 				this.players = [];
 
-				for(let i = 0; i < playerInfos.length; i += 2) {
-					this.players.push({ name: playerInfos[i], rating: Number(playerInfos[i + 1]) });
+				for(let i = 0; i < playerInfos.length; i += 3) {
+					this.players.push({ name: playerInfos[i], rating: Number(playerInfos[i + 1]), wins: Number(playerInfos[i + 2]) });
 				}
 			}).catch((err) => {
 				console.log(err);
@@ -50,8 +52,9 @@ export const PlayerList = Vue.defineComponent({
 		<ul class="playerList" id="playerList">
 			<li class="playerIndividual" v-for="(player, index) in players">
 				<img v-bind:src="'images/modal_boxes/puyo_' + puyoImgs[index % puyoImgs.length] + '.png'">
-				<span>{{player.name}}</span>
-				<span>{{player.rating}}</span>
+				<span >{{player.name}}</span>
+				<span class="centre-align">{{player.wins + '★'}}</span>
+				<span class="right-align">{{player.rating}}</span>
 			</li>
 		</ul>`
 });

--- a/src/webpage/firebase.ts
+++ b/src/webpage/firebase.ts
@@ -238,6 +238,10 @@ export class PlayerInfo {
 
 	/**
 	 * Updates a specific property of the user data.
+	 * @param	uid			UID of the user
+	 * @param 	property	Name of the property to be updated
+	 * @param	value		New value of the property be updated to
+	 * @param	overwrite	Whether to overwrite the property's children. False by default.
 	 */
 	static updateUser(uid: string, property: string, value: unknown, overwrite = true): void {
 		// Update the firebase auth User object if it is one of their properties

--- a/src/webpage/modals/RoomOptionsModal.ts
+++ b/src/webpage/modals/RoomOptionsModal.ts
@@ -21,12 +21,12 @@ export const RoomOptionsModal = Vue.defineComponent({
 				marginTime: 96,		// Set to seconds
 				numPlayers: 4,
 				hardDrop: false,
-				winCondition: 'FT 3'
+				winCondition: 'None'
 			}),
 			wildNumSelected: false,
 			puyoImgs,
 			gamemodes: Object.values(Gamemode),
-			winConditions: ['FT 3', 'FT 5', 'FT 7'],
+			winConditions: ['None', 'FT 3', 'FT 5', 'FT 7'],
 			disabled: false,
 			mode: 'create'
 		};

--- a/src/webpage/modals/RoomOptionsModal.ts
+++ b/src/webpage/modals/RoomOptionsModal.ts
@@ -86,7 +86,9 @@ export const RoomOptionsModal = Vue.defineComponent({
 			settings.numPlayers = undefined;	// Separate the numPlayers property from settings
 			settings.marginTime *= 1000;		// Convert margin time to milliseconds
 
-			this.emitter.emit('submitRoomSettings', { settings, roomSize: this.settings.numPlayers || 4, mode: this.mode });
+			const roomType = this.settings.winCondition === 'None' ? 'default' : this.settings.winCondition;
+
+			this.emitter.emit('submitRoomSettings', { settings, roomSize: this.settings.numPlayers || 4, mode: this.mode, roomType });
 		}
 	},
 	mounted() {

--- a/src/webpage/pages/guide.ts
+++ b/src/webpage/pages/guide.ts
@@ -52,7 +52,7 @@ export function initGuide(app: Vue.App<Element>, emitter: ReturnType<typeof mitt
 	emitter.on('startSimulator', (options: Options) => {
 		clearCells();
 		settings.setSeed(options.seed);		// Will default to random seed if none is provided
-		const gameAreas = generateCells(1, settings);
+		const gameAreas = generateCells(['test'], settings);
 		const game = new PlayerGame(null, ['system'], socket, settings, userSettings, gameAreas, audioPlayer);
 
 		if(options.nuisance) {
@@ -173,7 +173,7 @@ const GuideComponent = Vue.defineComponent({
 			this.currentPage = this.guidePages[this.pageNum];
 			clearCells();
 			if(this.currentPage.options.simulator) {
-				generateCells(1, settings);
+				generateCells(['test'], settings);
 			}
 			if(this.simulatorOn) {
 				this.stopSimulator();

--- a/src/webpage/panels_custom.ts
+++ b/src/webpage/panels_custom.ts
@@ -9,6 +9,13 @@ import { Settings, UserSettings } from '../utils/Settings';
 
 export const puyoImgs: string[] = ['red', 'blue', 'green', 'yellow', 'purple', 'teal'];
 
+interface RoomSettings {
+	settings: Settings;
+	roomSize: number;
+	mode: string;
+	roomType: string;
+}
+
 export function initCustomPanels(
 	emitter: ReturnType<typeof mitt>,
 	clearModal: () => void,
@@ -28,16 +35,16 @@ export function initCustomPanels(
 		emitter.emit('disableRoomSettings', false);
 	};
 
-	emitter.on('submitRoomSettings', ({settings, roomSize, mode}: {settings: Settings, roomSize: number, mode: string}) => {
+	emitter.on('submitRoomSettings', ({ settings, roomSize, mode, roomType }: RoomSettings) => {
 		const settingsString = Object.assign(new Settings(), settings).toString();
 		switch(mode) {
 			case 'create':
 				void stopCurrentSession().then(() => {
-					socket.emit('createRoom', { gameId: getCurrentUID(), settingsString, roomSize });
+					socket.emit('createRoom', { gameId: getCurrentUID(), settingsString, roomSize, roomType });
 				});
 				break;
 			case 'set':
-				socket.emit('changeSettings', getCurrentUID(), settingsString, roomSize);
+				socket.emit('changeSettings', getCurrentUID(), settingsString, roomSize, roomType);
 				break;
 		}
 		audioPlayer.playSfx('submit');

--- a/test/utils/Ratings.test.js
+++ b/test/utils/Ratings.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/*eslint-env mocha */
+
+const chaiExclude = require('chai-exclude');
+const { expect } = require('chai').use(chaiExclude);
+
+const { updateRatings, findDelta, findUncertainty } = require('../../src/utils/Ratings.js');
+
+describe('Ratings.js', function() {
+	describe('findDelta', function() {
+		it('should calculate the right delta', function() {
+			const delta = findDelta(0.8, 1.6, 15, 20);
+			expect(delta).to.be.closeTo(0.003536, 0.00001);
+		});
+	});
+
+	describe('updateRatings', function() {
+		it('should update the ratings correctly', function() {
+			const {ratingA, ratingB} = updateRatings(0.8, 1.6, 15, 20);
+			expect(ratingA).to.be.closeTo(0.8028288, 0.00001);
+			expect(ratingB).to.be.closeTo(1.5943623, 0.00001);
+		});
+	});
+
+	describe('findUncertainty', function() {
+		it('should calculate the right uncertainty', function() {
+			const timestamp = Date.now();
+
+			// B 15 - 10 A. B is rated 1.0, A is rated 0.4
+			// C 25 - 18 A. C is rated 0.5714, A is rated 0.4
+			const matches = {
+				'B': [{ wins: 10, opponent_wins: 15, timestamp }],
+				'C': [{ wins: 25, opponent_wins: 18, timestamp }]
+			};
+
+			/*
+				Coefficient of A against B is 0.0004, match strength is 0.0004 * 25 = 0.01.
+				This adds sqrt(0.01)/10 = 0.01 to total matchup strength.
+
+				Coefficient of A against C is 0.0005, match strength is 0.0005 * 43 = 0.0215
+				This adds sqrt(0.0215)/10 = 0.01466 to total matchup strength.
+
+				Total matchup strength is thus 0.01 + 0.01466 = 0.02466.
+				Uncertainty is 0.6/(0.02466^1.2) = 51.0151, approximately
+			 */
+
+			const all_ratings = {
+				'A': 0.4,
+				'B': 1.0,
+				'C': 0.8
+			}
+
+			const uncertainty = findUncertainty(0.4, matches, all_ratings);
+
+			expect(uncertainty).to.be.closeTo(51.0151, 0.0001);
+		});
+	});
+});


### PR DESCRIPTION
**New features:**
- A rating system very similar to Hiku's Western Ranking has been implemented.
  - Currently, there is no way to access this rating system as Ranked matches do not function properly yet.
- Player names are now shown beneath boards to help identify who's who.
- Lobbies without a win condition now keeps track of total wins in the player list.
- Lobbies with a FT # win condition now do not return to the lobby between games, and each player's wins are tracked underneath their board.

**Other changes:**
- Fixed #60, and likely other issues associated with the server not being able to figure out who won a game.
- CPUs no longer emit gameOver and gameEnd events twice (didn't cause any visible problems, but occasionally had some weird errors).
- Removed a lot of unnecessary/repeated code.